### PR TITLE
Add go.mod: connectrpc.com/validate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module connectrpc.com/validate
 
-go 1.21.0
+go 1.19


### PR DESCRIPTION
Add a `go.mod`, using the import path `connectrpc.com/validate`. Does this look
right, or should the import path and package name be `connectvalidate` (or
something else)?
