### PR TITLE
Add more validate-go maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,8 @@ Maintainers
 ## Current
 * [Akshay Shah](https://github.com/akshayjshah), [Buf](https://buf.build)
 * [Chris Roche](https://github.com/rodaine), [Buf](https://buf.build)
+* [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
+* [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
 
 ## Former
 * [Elliot Jackson](https://github.com/elliotmjackson)


### PR DESCRIPTION
Adds Ed and Josh as maintainers of this repo, so we can approve and merge maintenance PRs, like the two currently open.