### PR TITLE
Add John Chadwick to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,7 @@ Maintainers
 ## Current
 * [Akshay Shah](https://github.com/akshayjshah), [Buf](https://buf.build)
 * [Chris Roche](https://github.com/rodaine), [Buf](https://buf.build)
+* [John Chadwick](https://github.com/jchadwick-buf), [Buf](https://buf.build)
 * [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
 * [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
 


### PR DESCRIPTION
John has been the primary contributor to protovalidate and protovalidate-go for quite a while and has contributed to various connect projects including this one and connect-go. So I think he deserves to be in the maintainer list.