### PR TITLE
Use protovalidate.GlobalValidator by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,10 @@ import (
 )
 
 func main() {
-	interceptor, err := validate.NewInterceptor()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	mux := http.NewServeMux()
 	mux.Handle(userv1connect.NewUserServiceHandler(
 		&userv1connect.UnimplementedUserServiceHandler{},
-		connect.WithInterceptors(interceptor),
+		connect.WithInterceptors(validate.NewInterceptor()),
 	))
 
 	http.ListenAndServe("localhost:8080", mux)

--- a/validate.go
+++ b/validate.go
@@ -35,8 +35,9 @@ type Option interface {
 }
 
 // WithValidator configures the [Interceptor] to use a customized
-// [protovalidate.Validator]. See [protovalidate.ValidatorOption] for the range
-// of available customizations.
+// [protovalidate.Validator]. By default, [protovalidate.GlobalInterceptor]
+// is used See [protovalidate.ValidatorOption] for the range of available
+// customizations.
 func WithValidator(validator protovalidate.Validator) Option {
 	return optionFunc(func(i *Interceptor) {
 		i.validator = validator
@@ -86,21 +87,17 @@ type Interceptor struct {
 
 // NewInterceptor builds an Interceptor. The default configuration is
 // appropriate for most use cases.
-func NewInterceptor(opts ...Option) (*Interceptor, error) {
+func NewInterceptor(opts ...Option) *Interceptor {
 	var interceptor Interceptor
 	for _, opt := range opts {
 		opt.apply(&interceptor)
 	}
 
 	if interceptor.validator == nil {
-		validator, err := protovalidate.New()
-		if err != nil {
-			return nil, fmt.Errorf("construct validator: %w", err)
-		}
-		interceptor.validator = validator
+		interceptor.validator = protovalidate.GlobalValidator
 	}
 
-	return &interceptor, nil
+	return &interceptor
 }
 
 // WrapUnary implements connect.Interceptor.

--- a/validate_test.go
+++ b/validate_test.go
@@ -88,8 +88,7 @@ func TestInterceptorUnary(t *testing.T) {
 			if test.validateResponses {
 				opts = append(opts, validate.WithValidateResponses())
 			}
-			validator, err := validate.NewInterceptor(opts...)
-			require.NoError(t, err)
+			validator := validate.NewInterceptor(opts...)
 
 			mux := http.NewServeMux()
 			mux.Handle(userv1connect.UserServiceCreateUserProcedure, connect.NewUnaryHandler(
@@ -169,8 +168,7 @@ func TestInterceptorStreamingHandler(t *testing.T) {
 			if test.validateResponses {
 				opts = append(opts, validate.WithValidateResponses())
 			}
-			validator, err := validate.NewInterceptor(opts...)
-			require.NoError(t, err)
+			validator := validate.NewInterceptor(opts...)
 
 			mux := http.NewServeMux()
 			mux.Handle(calculatorv1connect.CalculatorServiceCumSumProcedure, connect.NewBidiStreamHandler(
@@ -194,7 +192,7 @@ func TestInterceptorStreamingHandler(t *testing.T) {
 				assert.NoError(t, stream.CloseRequest())
 			})
 
-			err = stream.Send(test.req)
+			err := stream.Send(test.req)
 			require.NoError(t, err)
 			time.Sleep(time.Second)
 			got, err := stream.Receive()
@@ -267,8 +265,7 @@ func TestInterceptorStreamingClient(t *testing.T) {
 			if test.validateResponses {
 				opts = append(opts, validate.WithValidateResponses())
 			}
-			validator, err := validate.NewInterceptor(opts...)
-			require.NoError(t, err)
+			validator := validate.NewInterceptor(opts...)
 
 			mux := http.NewServeMux()
 			mux.Handle(calculatorv1connect.CalculatorServiceCumSumProcedure, connect.NewBidiStreamHandler(
@@ -295,7 +292,7 @@ func TestInterceptorStreamingClient(t *testing.T) {
 				assert.NoError(t, stream.CloseRequest())
 			})
 
-			err = stream.Send(test.req)
+			err := stream.Send(test.req)
 			if test.wantCode > 0 {
 				require.Error(t, err)
 				var connectErr *connect.Error
@@ -330,7 +327,7 @@ func TestWithValidator(t *testing.T) {
 	t.Parallel()
 	validator, err := protovalidate.New(protovalidate.WithDisableLazy())
 	require.NoError(t, err)
-	interceptor, err := validate.NewInterceptor(validate.WithValidator(validator))
+	interceptor := validate.NewInterceptor(validate.WithValidator(validator))
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
This PR results in the new `protovalidate.GlobalValidator` being used by default instead of `protovalidate.New`. This global validator was not available when this library was written, and is Protovalidate's new recommendation. This eliminates the error from `NewInterceptor` as well.